### PR TITLE
refactor: pass in tasks to getMarkdownReport()

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,13 @@ This plug-in bundle also contains several functions in the `completedReportLib` 
 
 This function takes a start time and end time (in the Date format) as input and returns an array of the tasks that have been completed between the two times.
 
-## getMarkdownReport (startDate, endDate)
+## makeDateHeading (startDate, endDate)
 
-This function takes a start time and end time as input (in the Date format) and returns a string which a report showing the tasks that have been completed between the two times (in Markdown format).
+This function produces a markdown heading using the provided start and end dates.
+
+## getMarkdownReport (heading, tasksCompleted)
+
+This function takes a heading and an array of tasks as input, and returns a string which is a report listing the tasks (in Markdown format).
 
 ## runReportForPeriod (startDate, endDate, templateUrl)
 

--- a/Resources/completedReportLib.js
+++ b/Resources/completedReportLib.js
@@ -89,9 +89,7 @@
     return tasksCompleted
   }
 
-  completedReportLib.getMarkdownReport = (startDate, endDate, tasksCompleted) => {
-    const config = PlugIn.find('com.KaitlinSalzke.completedTaskReport').library('completedReportConfig')
-
+  completedReportLib.makeDateHeading = (startDate, endDate) => {
     let headingDates
     if (startDate.toDateString() === endDate.toDateString()) {
       headingDates = 'on ' + startDate.toDateString()
@@ -99,7 +97,13 @@
       headingDates =
         'from ' + startDate.toDateString() + ' to ' + endDate.toDateString()
     }
-    let markdown = '# Tasks Completed ' + headingDates + '\n'
+    return '# Tasks Completed ' + headingDates + '\n'
+  }
+
+  completedReportLib.getMarkdownReport = (heading, tasksCompleted) => {
+    const config = PlugIn.find('com.KaitlinSalzke.completedTaskReport').library('completedReportConfig')
+
+    let markdown = heading
     let currentFolder = 'No Folder'
     let currentProject = 'No Project'
     let lastTaskName = ''
@@ -165,7 +169,9 @@
       endDate
     )
 
-    const markdown = completedReportLib.getMarkdownReport(startDate, endDate, tasksCompleted)
+    const heading = completedReportLib.makeDateHeading(startDate, endDate)
+
+    const markdown = completedReportLib.getMarkdownReport(heading, tasksCompleted)
 
     if (templateUrl === 'CLIPBOARD') {
       Pasteboard.general.string = markdown

--- a/Resources/completedReportLib.js
+++ b/Resources/completedReportLib.js
@@ -89,13 +89,8 @@
     return tasksCompleted
   }
 
-  completedReportLib.getMarkdownReport = (startDate, endDate) => {
+  completedReportLib.getMarkdownReport = (startDate, endDate, tasksCompleted) => {
     const config = PlugIn.find('com.KaitlinSalzke.completedTaskReport').library('completedReportConfig')
-    // generate TaskPaper and send to Day One
-    const tasksCompleted = completedReportLib.getTasksCompletedBetweenDates(
-      startDate,
-      endDate
-    )
 
     let headingDates
     if (startDate.toDateString() === endDate.toDateString()) {
@@ -165,7 +160,12 @@
   }
 
   completedReportLib.runReportForPeriod = (startDate, endDate, templateUrl) => {
-    const markdown = completedReportLib.getMarkdownReport(startDate, endDate)
+    const tasksCompleted = completedReportLib.getTasksCompletedBetweenDates(
+      startDate,
+      endDate
+    )
+
+    const markdown = completedReportLib.getMarkdownReport(startDate, endDate, tasksCompleted)
 
     if (templateUrl === 'CLIPBOARD') {
       Pasteboard.general.string = markdown

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "identifier": "com.KaitlinSalzke.completedTaskReport",
   "author": "Kaitlin Salzke",
   "description": "Plugin to generate a daily completed task report from OmniFocus",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "actions": [
     { "identifier": "sendToDayOne" },
     { "identifier": "sendToDrafts" },


### PR DESCRIPTION
So that people can generate their own completed task list using more complex
filtering.

Works with Copy to Clipboard, but I don't have DayOne or Drafts to test with
those commands.  However, all three commands appear to share the same codepath
so I don't anticipate any issues.

Implements #3